### PR TITLE
Added optional --force parameter to the add sub-command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,7 +83,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-index"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "clap",
  "failure",
@@ -505,7 +505,7 @@ dependencies = [
 
 [[package]]
 name = "reg-index"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "cargo_metadata",
  "failure",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-index"
-version = "0.2.4"
+version = "0.2.5"
 authors = ["Eric Huss"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -14,7 +14,7 @@ repository = "https://github.com/ehuss/cargo-index"
 [dependencies]
 clap = "2.32.0"
 failure = "0.1.3"
-reg-index = { version = "0.4.0", path = "reg-index" }
+reg-index = { version = "0.4.1", path = "reg-index" }
 serde_json = "1.0.33"
 
 [dev-dependencies]

--- a/reg-index/Cargo.toml
+++ b/reg-index/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reg-index"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Eric Huss"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/reg-index/src/bin/scratch.rs
+++ b/reg-index/src/bin/scratch.rs
@@ -24,6 +24,7 @@ fn main() -> Result<(), Error> {
         "https://example.com",
         Some(&manifest_path),
         None,
+        false,
         None,
     )?;
     // Get the metadata for the new entry.

--- a/reg-index/src/bin/scratch.rs
+++ b/reg-index/src/bin/scratch.rs
@@ -24,7 +24,6 @@ fn main() -> Result<(), Error> {
         "https://example.com",
         Some(&manifest_path),
         None,
-        false,
         None,
     )?;
     // Get the metadata for the new entry.

--- a/reg-index/src/lib.rs
+++ b/reg-index/src/lib.rs
@@ -22,7 +22,7 @@ A very basic example:
 // Initialize a new index.
 reg_index::init(&index_path, "https://example.com", None)?;
 // Add a package to the index.
-reg_index::add(&index_path, index_url, Some(&manifest_path), None, false, None)?;
+reg_index::add(&index_path, index_url, Some(&manifest_path), None, None)?;
 // Packages can be yanked.
 reg_index::yank(&index_path, "foo", "0.1.0")?;
 // Get the metadata for the new entry.
@@ -58,7 +58,7 @@ mod util;
 mod validate;
 mod yank;
 
-pub use add::{add, add_from_crate};
+pub use add::{add, add_from_crate, force_add};
 pub use init::init;
 pub use list::{list, list_all};
 pub use metadata::{metadata, metadata_from_crate};

--- a/reg-index/src/lib.rs
+++ b/reg-index/src/lib.rs
@@ -22,7 +22,7 @@ A very basic example:
 // Initialize a new index.
 reg_index::init(&index_path, "https://example.com", None)?;
 // Add a package to the index.
-reg_index::add(&index_path, index_url, Some(&manifest_path), None, None)?;
+reg_index::add(&index_path, index_url, Some(&manifest_path), None, false, None)?;
 // Packages can be yanked.
 reg_index::yank(&index_path, "foo", "0.1.0")?;
 // Get the metadata for the new entry.

--- a/src/main.rs
+++ b/src/main.rs
@@ -267,15 +267,26 @@ fn add(args: &ArgMatches<'_>) -> Result<(), Error> {
     let force = args.is_present("force");
     let package_args = package_args(args)?;
     let reg_pkg = match (manifest_path, krate) {
-        (Some(_), None) | (None, None) => reg_index::add(
-            index_path,
-            index_url,
-            manifest_path,
-            upload,
-            force,
-            package_args.as_ref(),
-        ),
-        (None, Some(krate)) => reg_index::add_from_crate(index_path, index_url, krate, upload, force),
+        (Some(_), None) | (None, None) => {
+            if force {
+                reg_index::force_add(
+                    index_path,
+                    index_url,
+                    manifest_path,
+                    upload,
+                    package_args.as_ref(),
+                )
+            } else {
+                reg_index::add(
+                    index_path,
+                    index_url,
+                    manifest_path,
+                    upload,
+                    package_args.as_ref(),
+                )
+            }
+        },
+        (None, Some(krate)) => reg_index::add_from_crate(index_path, index_url, krate, upload),
         (Some(_), Some(_)) => bail!("Both --crate and --manifest-path cannot be specified."),
     }?;
     println!("{}:{} successfully added!", reg_pkg.name, reg_pkg.vers);

--- a/tests/test_index.rs
+++ b/tests/test_index.rs
@@ -127,6 +127,28 @@ fn test_add_errors() {
 }
 
 #[test]
+fn test_add_force() {
+    // TODO: Finish this.
+    let index = init_index();
+    let foo_pkg = package("foo", "0.1.0").build();
+    foo_pkg.index_add(&index);
+    let expected_index = "{\"name\":\"foo\",\"vers\":\"0.1.0\",\"deps\":[],\"features\":{},\"cksum\":\"<CKSUM>\",\"yanked\":false,\"links\":null}\n";
+    matches(&fs::read_to_string(index.index_path.join("3/f/foo")).unwrap(),
+            expected_index);
+    cargo_index("add")
+        .manifest(foo_pkg.join("Cargo.toml"))
+        .index(&index.index_path)
+        .index_url("https://example.com")
+        .arg("--force")
+        .with_status(0)
+        .run();
+    validate(&index, true);
+    // Nothing should have changed when the same package is added.
+    matches(&fs::read_to_string(index.index_path.join("3/f/foo")).unwrap(),
+            expected_index);
+}
+
+#[test]
 fn test_add_renamed() {
     if !is_nightly() {
         // Remove once alt_registry is stable.


### PR DESCRIPTION
…that will update an indexed crate version, even if that version already exists in the index. The intention here is when very quick, minor changes are made such that a version bump isn't warranted.

Happy to hear any feedback you might have on this as this is my first pull request on GitHub.