### PR TITLE
Add ignore feature to list_all

### DIFF
--- a/reg-index/src/list.rs
+++ b/reg-index/src/list.rs
@@ -38,6 +38,7 @@ pub fn list_all(
     index: impl AsRef<Path>,
     pkg_name: Option<&str>,
     version_req: Option<&str>,
+    ignore_error: bool,
     mut cb: impl FnMut(Vec<IndexPackage>),
 ) -> Result<(), Error> {
     let index = index.as_ref();
@@ -54,8 +55,14 @@ pub fn list_all(
         for entry in crate_walker(index) {
             let entry = entry?;
             let pkg_name = entry.file_name().to_str().unwrap();
-            let entries = _list(index, pkg_name, version_req.as_ref())?;
-            cb(entries);
+            match _list(index, pkg_name, version_req.as_ref()) {
+              Ok(entries) =>  cb(entries),
+              Err(e) => if ignore_error {
+                eprintln!("{}", e)
+              } else {
+                return Err(e);
+              }
+            }
         }
     };
     drop(lock);

--- a/src/main.rs
+++ b/src/main.rs
@@ -329,7 +329,7 @@ fn list(args: &ArgMatches<'_>) -> Result<(), Error> {
     let pkg = args.value_of("package");
     let version = args.value_of("version");
     let mut count = 0;
-    reg_index::list_all(args.value_of("index").unwrap(), pkg, version, |entries| {
+    reg_index::list_all(args.value_of("index").unwrap(), pkg, version, false, |entries| {
         for entry in entries {
             count += 1;
             println!("{}", serde_json::to_string(&entry).unwrap());


### PR DESCRIPTION
I needed to add this cause I found no other way to handle some invalid package in the registry, thus, I don't know if this approach is the best, it's was a Q&D commit for my need, it's may be better to let user handle it with `cb` function.