### PR TITLE
Fix using a relative path to manifest-path

### DIFF
--- a/reg-index/src/util.rs
+++ b/reg-index/src/util.rs
@@ -34,8 +34,6 @@ pub(crate) fn cargo_package(
 ) -> Result<PathBuf, Error> {
     let mut cmd = Command::new("cargo");
     cmd.arg("package")
-        .arg("--manifest-path")
-        .arg(manifest_path)
         .current_dir(manifest_path.parent().unwrap());
     if let Some(args) = package_args {
         cmd.args(args);

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -106,7 +106,6 @@ impl TestBuilder {
         let path = path.as_ref();
         self.arg("--manifest-path");
         self.arg(path);
-        self.cwd(path.parent().unwrap());
         self
     }
 

--- a/tests/test_index.rs
+++ b/tests/test_index.rs
@@ -4,6 +4,7 @@ use self::support::{
 };
 use reg_index::IndexPackage;
 use std::fs;
+use std::path::Path;
 
 #[test]
 fn test_init() {
@@ -52,6 +53,17 @@ fn test_metadata() {
          \"deps\":[],\"features\":{{}},\"cksum\":\"{}\",\"yanked\":false,\"links\":null}}\n",
         reg_pkg.cksum
     );
+    assert_eq!(stdout, expected);
+
+    // Try with a relative path.
+    let foo_path = foo_pkg.path();
+    let parent = foo_path.parent().unwrap();
+    let relative = Path::new(foo_path.file_name().unwrap()).join("Cargo.toml");
+    let (stdout, _stderr) = cargo_index("metadata")
+        .index_url("https://example.com")
+        .cwd(parent)
+        .manifest(relative)
+        .run();
     assert_eq!(stdout, expected);
 }
 


### PR DESCRIPTION
A relative path for `--manifest-path` was not working because it was both changing the cwd and passing `--manifest-path`, which won't work.

Closes #13