### PR TITLE
Pass `--no-deps` to `cargo metadata`

### DIFF
--- a/reg-index/src/metadata.rs
+++ b/reg-index/src/metadata.rs
@@ -88,6 +88,7 @@ pub(crate) fn metadata_reg(
             cmd.manifest_path(path);
         }
     }
+    cmd.no_deps();
     let metadata =
         cmd.exec()
             .map_err(|e| format_err!("{}", e))


### PR DESCRIPTION
Information about dependencies beyond workspace members is unnecessary in this case. `--no-deps` makes it easier to use this tool in an offline context.