### PR TITLE
Update version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,7 +103,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-index"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "anyhow",
  "clap",
@@ -471,7 +471,7 @@ dependencies = [
 
 [[package]]
 name = "reg-index"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 
 [package]
 name = "cargo-index"
-version = "0.2.6"
+version = "0.2.7"
 authors = ["Eric Huss"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -20,7 +20,7 @@ rust-version = "1.70"
 [dependencies]
 anyhow = "1.0.58"
 clap = { version = "4.4.6", features = ["cargo"] }
-reg-index = { version = "0.5.0", path = "reg-index" }
+reg-index = { version = "0.6.0", path = "reg-index" }
 serde_json = "1.0.33"
 
 [dev-dependencies]

--- a/reg-index/Cargo.toml
+++ b/reg-index/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reg-index"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Eric Huss"]
 edition = "2021"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
This bumps the version for a new release.

The SemVer-incompatible update of 0.5 to 0.6 may not be strictly necessary, but since there were a lot of changes I felt it would be safer. In particular, the cargo_metadata type is exposed in the public API, and there was a SemVer-incompatible bump of that version.
